### PR TITLE
initialize totalatoms to zero in readInput.cpp

### DIFF
--- a/SCRAPs/readInput.cpp
+++ b/SCRAPs/readInput.cpp
@@ -48,6 +48,7 @@ void readInput::readPOSCAR()
 {
     stringstream ss;
     int linnumb = 1;
+    int totalatoms = 0;
     string line, key;
     std::ifstream inp ("./POSCAR");
     if (inp.is_open()) {


### PR DESCRIPTION
`totalatoms` was being randomly initialized, which could result in a negative number, which breaks the logic of the `readPOSCAR` loop. 
I added 
```cpp
int totalatoms = 0;
```
at the start of `readPOSCAR` , which fixed intermittent failures.